### PR TITLE
Should use getBaseUrl instead of getRootUrl in startHistoryJs

### DIFF
--- a/pager.js
+++ b/pager.js
@@ -1,7 +1,5 @@
 (function (window) {
 
-    var History = window.History;
-
     var pagerJsModule = function ($, ko) {
 
         "use strict";
@@ -1331,7 +1329,7 @@
 
         pager.Href5.prototype = new pager.Href();
 
-        pager.Href5.history = window.history;
+        pager.Href5.history = window.History;
 
         pager.Href5.prototype.bind = function () {
             var self = this;
@@ -1453,15 +1451,15 @@
             }
 
             // Bind to StateChange Event
-            History.Adapter.bind(window, 'statechange', function () {
-                var relativeUrl = History.getState().url.replace(History.getBaseUrl(), '');
+            pager.Href5.history.Adapter.bind(window, 'statechange', function () {
+                var relativeUrl = pager.Href5.history.getState().url.replace(pager.Href5.history.getBaseUrl(), '');
                 goTo(relativeUrl);
             });
-            History.Adapter.bind(window, 'anchorchange', function () {
+            pager.Href5.history.Adapter.bind(window, 'anchorchange', function () {
                 goTo(location.hash);
             });
 
-            goTo(History.getState().url.replace(History.getBaseUrl(), ''));
+            goTo(pager.Href5.history.getState().url.replace(pager.Href5.history.getBaseUrl(), ''));
         };
 
         pager.startHashChange = function (id) {


### PR DESCRIPTION
goTo(pager.Href5.history.getState().url.replace(pager.Href5.history.getRootUrl(), ''));
should be
goTo(pager.Href5.history.getState().url.replace(pager.Href5.history.getBaseUrl(), ''));

Otherwise pager will not match the correct url when deployed under other context paths than the root

Same goes for History.Adapter.bind(window, 'statechange'...)

This pull request also fixes #108
