### PR TITLE
workaround for knockout JS creation problem

### DIFF
--- a/pager.js
+++ b/pager.js
@@ -56,6 +56,60 @@
                 delete copy['$__page__'];
                 return copy;
             };
+            viewModel.toJSONByPrototype = function(_theDataModel){
+                var isNumber = function (obj) {
+                    return (toString.call(obj) == "[object " + Number + "]") || !isNaN(obj);
+                };
+                var isString = function (obj) {
+                    return "[object String]" == toString.call(obj);
+                };
+                var isObject = function (obj) {
+                    return obj === Object(obj);
+                };
+                var isBoolean = function(obj) {
+                    return obj === true || obj === false || toString.call(obj) == '[object Boolean]';
+                };
+                var isArray = Array.isArray || function(obj) {
+                    return toString.call(obj) == '[object Array]';
+                };
+                var isFunction = function (obj) {
+                    return toString.call(obj) == "[object " + Function + "]";
+                };
+                if (typeof (/./) !== 'function') {
+                    isFunction = function(obj) {
+                        return typeof obj === 'function';
+                    };
+                }
+                var toInnerJSON = function(obj, dataModel, viewModel){
+                    Object.keys(dataModel).forEach( function(key, index, array){
+                        var value = dataModel[key];
+                        if( isArray( value ) ){
+                            if( isFunction( viewModel[key] ) ){
+                                obj[ key ] = viewModel[key]();
+                            } else if( isArray( viewModel[key] ) ){
+                                obj[ key ] = [];
+                                viewModel[key].forEach( function(element, _index, _array){
+                                    if( isFunction( element ) )
+                                        obj[ key ].push( element() );
+                                } );
+                            }
+                        }
+                        else if( isString( value ) || isNumber( value ) || isBoolean( value ) ){
+                            if( viewModel[ key ] && isFunction( viewModel[ key ] ) ){
+                                obj[ key ] = viewModel[ key ]();
+                            }
+                        }
+                        else if( isObject( value ) ){
+                            obj[ key ] = {};
+                            toInnerJSON( obj[ key ], dataModel[ key ], viewModel[ key ] );
+                        }
+                    });
+                    return obj;
+                };
+
+                return toInnerJSON( {}, _theDataModel, this );
+            };
+
         };
 
         var fire = function (scope, name, options) {


### PR DESCRIPTION
Dear Oscar, 

I took the liberty to add a new function to the view model: toJSONByPrototype when the method extendWithPage is executed.

This allows one to generate the JS by a model prototype. When I download a data model from server side and create the viewmodel for knockout, I can use this as a "prototype" for JS creation. 

This will prevent the knockout to go and touch properties which do not belong to the model.

Considering, that your library must be functional on almost any knockout lib, i post this change here and not to the knockout lib.
