### PR TITLE
Do not overwrite nameParam on view model if it is already defined (fixes #100)

### DIFF
--- a/pager.js
+++ b/pager.js
@@ -845,7 +845,7 @@
                 });
             }
             var nameParam = this.getValue()['nameParam'];
-            if (nameParam && typeof nameParam === 'string') {
+            if (nameParam && typeof nameParam === 'string' && !m.ctx[nameParam]) {
                 m.ctx[nameParam] = ko.observable(null);
             }
             this.setParams();


### PR DESCRIPTION
Issue #100 seems to be due to augmentContext not properly checking if the viewmodel already has a property of the same name as nameParam. augmentContext overwrites it with a new observable, so old bindings relying on the old observable are not updated.

This fix checks if the viewmodel already has the property, and uses that instead.
