### PR TITLE
Upgrade to Grunt 0.4.0 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 /*global module:false*/
 module.exports = function (grunt) {
 
+    grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-less');
     grunt.loadNpmTasks('grunt-contrib-qunit');
 
@@ -17,9 +18,6 @@ module.exports = function (grunt) {
         server:{
             port:8000,
             base:'.'
-        },
-        lint:{
-            files:['pager.js', 'test/**/*.js']
         },
         qunit:{
             files:['test/**/*.html']
@@ -45,6 +43,7 @@ module.exports = function (grunt) {
             tasks:'lint qunit'
         },
         jshint:{
+            files: ['pager.js', 'test/**/*.js'],
             options:{
                 curly:true,
                 eqeqeq:true,
@@ -87,8 +86,8 @@ module.exports = function (grunt) {
     });
 
     // Default task.
-    grunt.registerTask('default', 'lint less qunit concat min');
+    grunt.registerTask('default', ['jshint', 'less', 'qunit', 'concat', 'min']);
 
-    grunt.registerTask('travis', 'qunit lint');
+    grunt.registerTask('travis', ['qunit', 'jshint']);
 
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     },
     "devDependencies": {
         "grunt": "~0.4",
+        "grunt-contrib-jshint": "~0.4",
         "grunt-contrib-qunit": "~0.4"
     },
     "keywords": ["knockout"]


### PR DESCRIPTION
Hi Oscar - this pull request is an upgrade to Grunt 0.4.0.  I was trying to look at some other issue and was struggling to get "grunt qunit" to spawn phantomjs on Windows.  Node's "spawn" function doesn't work so well on Windows when the thing you want to spawn is a .cmd file, and Grunt 0.4.0 added a workaround for this.  (see: https://github.com/gruntjs/grunt/issues/155) 
