### PR TITLE
Changed name of Knockout Bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "lib"
   ],
   "dependencies": {
-    "knockoutjs": ">=2.2.0",
+    "knockout": ">=2.2.0",
     "jquery": ">=1.7.3"
   }
 }


### PR DESCRIPTION
The "official" Bower package name for Knockout is "knockout" (see http://knockoutjs.com/downloads/index.html). This should allow other packages to share the same package dependency.