### PR TITLE
Allow for ctrl/command/shift new windows for html5 links.

### DIFF
--- a/pager.js
+++ b/pager.js
@@ -1426,10 +1426,14 @@
                 attr: {
                     'href': self.path
                 },
-                click: function () {
+                click: function (data, e) {
                     var path = self.path();
                     if (path === '' || path === '/') {
                         path = $('base').attr('href');
+                    }
+                    if (e.shiftKey || e.ctrlKey || e.metaKey) {
+                      window.open(path, '_blank');
+                      return;
                     }
                     pager.Href5.history.pushState(null, null, path);
                 }


### PR DESCRIPTION
Allow users to open a new window with ctrl/shift/command on html5 links.
