### PR TITLE
Delay show after finishing hide

### DIFF
--- a/pager.js
+++ b/pager.js
@@ -1496,7 +1496,7 @@
         pager.fx.jQuerySync = function (show, hide) {
             return {
                 showElement: function (page, callback) {
-                    show.call($(page.element), 300, callback);
+                    setTimeout(function () { show.call($(page.element), 300, callback); }, 300);
                 },
                 hideElement: function (page, callback) {
                     hide.call($(page.element), 300, function () {


### PR DESCRIPTION
In FX part, Pagerjs start showing and hidding at the same time. we have double display behavior (previous and next content). This problem is visible in demo part (be quick). 
Workaround is to delay show after hide sequence. Now it double FX duration (300 and then 300 more) but problem disapear.
