### PR TITLE
added update notice to the crawling info page

### DIFF
--- a/pagerjs.com/demo/page/misc/crawling.html
+++ b/pagerjs.com/demo/page/misc/crawling.html
@@ -17,6 +17,22 @@
         at Googles site about
         <a href="https://developers.google.com/webmasters/ajax-crawling/">Making AJAX Applications Crawlable</a>.
     </p>
+
+    <a target="_blank" href="?_escaped_fragment_=/misc/crawling">See the snapshot of this AJAX page.</a>.
+
+    <br/>
+    <br/>
+    <p class="lead">
+        <i class="label label-important">Update</i>
+        <br/>
+        Google <a target="_blank" href="https://webmasters.googleblog.com/2015/10/deprecating-our-ajax-crawling-scheme.html">officially deprecated</a>
+        their AJAX crawling scheme in 2015, telling _escaped_fragment_ URLs have become superfluous for them:
+        <br/>
+        <blockquote class="bg-info">
+            Instead of the _escaped_fragment_ URLs, we'll generally crawl, render, and index the #! URLs.
+            [...]
+            If you're building a new site or restructuring an already existing site, simply avoid introducing _escaped_fragment_ urls.
+        </blockquote>
+    </p>
 </header>
 
-<a target="_blank" href="?_escaped_fragment_=/misc/crawling">See the snapshot of this AJAX page.</a>.


### PR DESCRIPTION
From Google's perspective, _escaped_fragment_ URLs have become superfluous, so I thought it was worth a notice in the crawling info page.
