### PR TITLE
Fix bug when reloading page with parameters in URL

### DIFF
--- a/pager.js
+++ b/pager.js
@@ -815,7 +815,7 @@
             if (urlToggle !== 'none') {
                 // check if this page should trigger showChild at parent
                 var parent = m.parentPage;
-                if (parent.route && (parent.route[0].split('?')[0] === m.getId() || (parent.route.length && m.getId() === '?') )) {
+                if (parent.route && parent.route.length && (parent.route[0].split('?')[0] === m.getId() || m.getId() === '?')) {
                     // call once the current event loop is finished.
                     setTimeout(function () {
                         parent.showPage(parent.route);

--- a/pager.js
+++ b/pager.js
@@ -815,7 +815,7 @@
             if (urlToggle !== 'none') {
                 // check if this page should trigger showChild at parent
                 var parent = m.parentPage;
-                if (parent.route && (parent.route[0] === m.getId() || (parent.route.length && m.getId() === '?') )) {
+                if (parent.route && (parent.route[0].split('?')[0] === m.getId() || (parent.route.length && m.getId() === '?') )) {
                     // call once the current event loop is finished.
                     setTimeout(function () {
                         parent.showPage(parent.route);


### PR DESCRIPTION
This was a fun one to track down.

First off, thanks for making and maintaining Pager, we use it on a fairly large web app (~30 pages) and haven't had too many issues so far.  However, we did run into an issue that when you reload a nested page that has query params attached, it never loaded the page.  I tracked down the bug to be on line 818.  The issue was that the page being loaded (`m.getId()`) was `Ticket`, but the `parent.route[0]` was `Ticket?uid=<guid>`, so because those did not match it did not trigger `parent.showPage` and thus the page was never shown.

This fix is pretty straight forward, and I would appreciate if you can merge into the next release and let me know when it goes out on NPM so I can switch our project back to using this repo instead of my fork.  Let me know if you want me to make any changes.